### PR TITLE
Fix deprecations

### DIFF
--- a/src/inputs.jl
+++ b/src/inputs.jl
@@ -69,7 +69,7 @@ function form(questions; style = :incremental)
         end
     end
     f = Form(questions,ScrollableChain(widgets),
-        [k => i for (i,(k,_)) in enumerate(questions)],
+        Dict(k => i for (i,(k,_)) in enumerate(questions)),
         Dict{Symbol,Any}())
     for (k,q) in questions
         on_done(q.input) do v

--- a/src/iterm2.jl
+++ b/src/iterm2.jl
@@ -3,7 +3,7 @@
 
 function prepare_display_file(buf;filename="Unnamed file", size=nothing, width=nothing, height=nothing, preserveAspectRatio::Bool=true, inline::Bool=false)
     q = "\e]1337;File="
-    options = ASCIIString[]
+    options = String[]
     filename != "Unnamed file" && push!(options,"name=" * base64encode(filename))
     size !== nothing && push!(options,"size=" * dec(size))
     height !== nothing && push!(options,"height=" * dec(height))

--- a/src/render.jl
+++ b/src/render.jl
@@ -39,7 +39,7 @@ typealias LocOrRect Union{CellLoc,CellRect}
 ==(x::LocOrRect,y::Tuple{Int,Int}) = x == (typeof(x))(y...)
 ==(x::Tuple{Int,Int},y::LocOrRect) = (typeof(y))(x...) == y
 
-getindex(x::LocOrRect,i) = x.(i)
+getindex(x::LocOrRect,i) = getfield(x,i)
 
 # Used to minimize the number of characters to be written.
 # The written characters themselves still have to be buffered,

--- a/src/widgets.jl
+++ b/src/widgets.jl
@@ -820,9 +820,11 @@ Base.println(t::TextInput) = error()
 # REPLWidget
 import Base: LineEdit
 import Base.LineEdit: ModalInterface
-import Base.REPL: AbstractREPL, MIRepl
+import Base.REPL: AbstractREPL
 
-if !isdefined(Base.REPL,:MIRepl)
+if isdefined(Base.REPL,:MIRepl)
+    import Base.REPL.MIRepl
+else
     const MIRepl = Base.REPL.LineEditREPL
 end
 

--- a/test/regressions.jl
+++ b/test/regressions.jl
@@ -3,7 +3,7 @@ using TerminalUI; using VT100
 const thisdir = dirname(@__FILE__)
 
 function test_against(em,file)
-    output = open(readbytes,joinpath(thisdir,file))
+    output = open(read,joinpath(thisdir,file))
     buf = IOBuffer()
     VT100.dump(buf,DevNull,em)
     outbuf = takebuf_array(buf)


### PR DESCRIPTION
This fixes #6. Tests fail; `failed.out` has some additional whitespace at the end. I don't know whether that's something to worry about or not, so I'll leave that fix to you.
